### PR TITLE
Fixed /openai path bug and added setup instructions

### DIFF
--- a/apim-policy.xml
+++ b/apim-policy.xml
@@ -159,7 +159,7 @@
                     return 0;    
                 }
                 }" />
-            <set-variable name="backendUrl" value="@(((JObject)((JArray)context.Variables["listBackends"])[(Int32)context.Variables["backendIndex"]]).Value<string>("url"))" />
+            <set-variable name="backendUrl" value="@(((JObject)((JArray)context.Variables["listBackends"])[(Int32)context.Variables["backendIndex"]]).Value<string>("url") + "openai")" />
             <set-backend-service base-url="@((string)context.Variables["backendUrl"])" />
             <forward-request buffer-request-body="true" />
             <choose>


### PR DESCRIPTION
Changes:

- Added documentation on how to set it up, step by step
- Added fix for issue where `/openai` is missing in the path when important the OpenAPI spec for AOAI